### PR TITLE
Generate a baseline Docker image

### DIFF
--- a/benchmarks/earthquake/new/Dockerfile
+++ b/benchmarks/earthquake/new/Dockerfile
@@ -1,0 +1,33 @@
+ARG PYTHON_VERSION=3.9.7
+FROM python:${PYTHON_VERSION}-slim-bullseye
+
+# This makes bash the default RUN shell instead of /bin/sh
+SHELL ["/bin/bash", "-c"]
+
+RUN mkdir -p /benchmark
+
+COPY . /benchmark/
+
+WORKDIR /benchmark
+
+
+RUN apt-get update && apt-get install -y xz-utils curl && \
+    python -m venv --prompt mlcommons-science venv && \
+    source venv/bin/activate && \
+    python -m pip install -U pip && \
+    python -m pip install -rrequirements.txt
+
+# TODO: Wire in data volume to either google drive or to a known
+# data anchor.
+# Optionally, we could bring the the data with us, as it compresses
+# to about 9MBs using lzma2/xz.
+VOLUME /data
+#RUN ln -s /data /benchmark/data
+
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Linux-x86_64.sh && \
+    bash ./Miniconda3-py39_4.10.3-Linux-x86_64.sh -b -p ~/miniconda && \
+    rm Miniconda3-py39_4.10.3-Linux-x86_64.sh
+
+ENV PATH /root/miniconda/condabin:$PATH
+ENTRYPOINT ["/benchmark/scripts/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/benchmarks/earthquake/new/environment.yml
+++ b/benchmarks/earthquake/new/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - jupyterlab
   - conda-forge::watermark>=2.3.0,<2.4.0
   - py-cpuinfo>=8.0.0,<8.1.0
-  - tabulate>0.8.9,<0.9.0
+  - tabulate>=0.8.9,<0.9.0
   - conda-forge::gputil>=1.4.0,<1.5.0
   - conda-forge::jupytext>=1.13.6,<1.14.0
   - pip:

--- a/benchmarks/earthquake/new/readme.md
+++ b/benchmarks/earthquake/new/readme.md
@@ -43,3 +43,14 @@ conda activate mlcommons-science
 python -m pip install -rrequirements-dev.txt
 jupyter lab .
 ```
+
+## Building the container image
+
+To build a container image of the entire benchmarking system (but not run the benchmark), you can run the commands
+
+```bash
+# If running docker
+$ docker image build --tag mlcommons-science-earthquake:latest
+# If running nerdctl
+$ nerdctl image build --tag mlcommons-science-earthquake:latest
+```

--- a/benchmarks/earthquake/new/requirements.txt
+++ b/benchmarks/earthquake/new/requirements.txt
@@ -16,4 +16,4 @@ tensorflow>=2.6.0,<2.7.0
 tensorflow_datasets>=4.0.1
 tqdm>=4.62.3,<4.63.0
 watermark>=2.3.0,<2.4.0
-wheel
+wheel ; sys_platform == 'win32'

--- a/benchmarks/earthquake/new/scripts/entrypoint.sh
+++ b/benchmarks/earthquake/new/scripts/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /benchmark/venv/bin/activate
+
+exec "$@"


### PR DESCRIPTION
This is a first-cut at creating a docker image that can be used for singularity runs.  It bootstraps python 3.9.7 with our requirements.txt entries within a virtual environment, and also copies all the contents of the earthquake data into a working directory `/benchmark`.

In the future, the `/data` folder will be wired in to the runtime as a volume so we can modify the source data without having to rebuild the container.