### PR TITLE
earthquake: may2022 - applying copy fix when permissions cannot be replicated across disk volumes.

### DIFF
--- a/benchmarks/earthquake/may2022/experiments/dgxstation/dgx.in.slurm
+++ b/benchmarks/earthquake/may2022/experiments/dgxstation/dgx.in.slurm
@@ -345,7 +345,7 @@ cp "${RUN_BASE}/FFFFWNPFEARTHQ_newTFTv29-${RUN_USER}-${GIT_REV}_output.ipynb" \
 
 echo "Saving graphical outputs to ${NB_OUTPUT}/gfx"
 mkdir -p ${NB_OUTPUT}/images
-cp -a "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
+cp -R "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
 
 echo "Execution Complete"
 exit 0

--- a/benchmarks/earthquake/may2022/experiments/docker/docker.in.slurm
+++ b/benchmarks/earthquake/may2022/experiments/docker/docker.in.slurm
@@ -345,7 +345,7 @@ cp "${RUN_BASE}/FFFFWNPFEARTHQ_newTFTv29-${RUN_USER}-${GIT_REV}_output.ipynb" \
 
 echo "Saving graphical outputs to ${NB_OUTPUT}/gfx"
 mkdir -p ${NB_OUTPUT}/images
-cp -a "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
+cp -R "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
 
 echo "Execution Complete"
 exit 0

--- a/benchmarks/earthquake/may2022/experiments/rivanna-2epoch/rivanna.in.slurm
+++ b/benchmarks/earthquake/may2022/experiments/rivanna-2epoch/rivanna.in.slurm
@@ -333,7 +333,7 @@ cp "${RUN_BASE}/FFFFWNPFEARTHQ_newTFTv29-${RUN_USER}-${GIT_REV}_output.ipynb" \
 
 echo "Saving graphical outputs to ${NB_OUTPUT}/gfx"
 mkdir -p ${NB_OUTPUT}/images
-cp -a "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
+cp -R "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
 
 echo "Execution Complete"
 exit 0

--- a/benchmarks/earthquake/may2022/experiments/rivanna/rivanna.in.slurm
+++ b/benchmarks/earthquake/may2022/experiments/rivanna/rivanna.in.slurm
@@ -336,7 +336,7 @@ cp "${RUN_BASE}/FFFFWNPFEARTHQ_newTFTv29-${RUN_USER}-${GIT_REV}_output.ipynb" \
 
 echo "Saving graphical outputs to ${NB_OUTPUT}/images"
 mkdir -p ${NB_OUTPUT}/images
-cp -a "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
+cp -R "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
 
 echo "Execution Complete"
 exit 0

--- a/benchmarks/earthquake/may2022/experiments/summit/summit.in.slurm
+++ b/benchmarks/earthquake/may2022/experiments/summit/summit.in.slurm
@@ -344,7 +344,7 @@ cp "${RUN_BASE}/FFFFWNPFEARTHQ_newTFTv29-${RUN_USER}-${GIT_REV}_output.ipynb" \
 
 echo "Saving graphical outputs to ${NB_OUTPUT}/gfx"
 mkdir -p ${NB_OUTPUT}/images
-cp -a "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
+cp -R "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
 
 echo "Execution Complete"
 exit 0

--- a/benchmarks/earthquake/may2022/experiments/ubuntu-sh/ubuntu.in.slurm
+++ b/benchmarks/earthquake/may2022/experiments/ubuntu-sh/ubuntu.in.slurm
@@ -334,7 +334,7 @@ cp "${RUN_BASE}/FFFFWNPFEARTHQ_newTFTv29-${RUN_USER}-${GIT_REV}_output.ipynb" \
 
 echo "Saving graphical outputs to ${NB_OUTPUT}/gfx"
 mkdir -p ${NB_OUTPUT}/images
-cp -a "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
+cp -R "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
 
 echo "Execution Complete"
 exit 0

--- a/benchmarks/earthquake/may2022/experiments/ubuntu-slurm/ubuntu.in.slurm
+++ b/benchmarks/earthquake/may2022/experiments/ubuntu-slurm/ubuntu.in.slurm
@@ -334,7 +334,7 @@ cp "${RUN_BASE}/FFFFWNPFEARTHQ_newTFTv29-${RUN_USER}-${GIT_REV}_output.ipynb" \
 
 echo "Saving graphical outputs to ${NB_OUTPUT}/gfx"
 mkdir -p ${NB_OUTPUT}/images
-cp -a "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
+cp -R "${RUN_BASE}/data/EarthquakeDec2020/Outputs" ${NB_OUTPUT}/images
 
 echo "Execution Complete"
 exit 0


### PR DESCRIPTION
This PR should wait until another person (perhaps @Toble007 ) can verify the `latest` execution works properly with the 2epoch works.

This mirrors the updates made in PR20 which applied the fixes to the `latest` execution.