### PR TITLE
earthquake: Updated scripts to use the a100 card name to keep experiment configurations consistent.

### DIFF
--- a/benchmarks/earthquake/latest/experiments/rivanna/rivanna-dgx-shm.yaml
+++ b/benchmarks/earthquake/latest/experiments/rivanna/rivanna-dgx-shm.yaml
@@ -10,7 +10,7 @@ data:
   images: images
 
 experiment:
-  card_name: 1
+  card_name: "a100"
   gpu_count: 1
   cpu_num: 6
   mem: "32GB"

--- a/benchmarks/earthquake/latest/experiments/rivanna/rivanna-dgx.in.slurm
+++ b/benchmarks/earthquake/latest/experiments/rivanna/rivanna-dgx.in.slurm
@@ -8,7 +8,7 @@
 #SBATCH -c {experiment.cpu_num}
 #SBATCH --mem={experiment.mem}
 #SBATCH --time={time}
-#SBATCH --gres=gpu:{experiment.gpu_count}
+#SBATCH --gres=gpu:{experiment.card_name}:{experiment.gpu_count}
 #SBATCH --mail-user=%u@virginia.edu
 #SBATCH --mail-type=ALL
 

--- a/benchmarks/earthquake/latest/experiments/rivanna/rivanna-dgx.yaml
+++ b/benchmarks/earthquake/latest/experiments/rivanna/rivanna-dgx.yaml
@@ -10,7 +10,7 @@ data:
   images: images
 
 experiment:
-  card_name: 1
+  card_name: "a100"
   gpu_count: 1
   cpu_num: 6
   mem: "32GB"


### PR DESCRIPTION
Simple update to convert the DGX runs to provide the a100 card name.  This involved updating the -dgx.in.slurm script to add the experiment parameter to the `gres` line and augmenting the YAML files to have the `card_name` as "a100" instead of "1".